### PR TITLE
Subclass Environment to simplify logic, add from_config

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -1,32 +1,39 @@
 import numpy as np
 import toml
 
+
+class InitialCondition:
+    def __init__(self, config):
+        self.m = np.array(config['mass'])
+        self.positions = np.array(config[['x', 'y', 'z']])
+        self.velocities = np.array(config[['vx', 'vy', 'vz']])
+
+
 class Environment:
     """ Environment contains all the necessary
     utilities to move the point mass bodies and 
     calculate the gravitation interactions between each body.
     """
-    def __init__(self, config=None, config_id=None,
-            settings_file="configuration/settings.toml"):
+
+    def __init__(
+        self,
+    ):
         """ Setup the environment.
 
         :param config: is a preset configuration defined? (T/F)
-        :param confid_id: the ID of the particular initial 
+        :param config_id: the ID of the particular initial
             configuraiton defined in the settings.
         :param settings_file: path of the settings to load.
         """
-        self.config = config
-        self.config_id = config_id
-        self.settings = toml.load(settings_file)
-        self.dt = self.settings["environment"]["dt"]
+        self.initial_conditions = None
+        self.config = None
+        self.config_id = None
+        self.settings = None
+        self.dt = 0
         self.gt = 0
-
-        if self.config is not None:
-            self.N = self.config.shape[0]
-            self.G = self.settings['configs'][self.config_id]['G']
-        else:
-            self.N = self.settings['environment']['n']
-            self.G = self.settings['const']['G']
+        self.N = 0
+        self.G = 0
+        self.t_max = 0
 
         # Placeholders
         self.names = np.empty(self.N)
@@ -34,115 +41,96 @@ class Environment:
         self.positions = np.zeros((self.N, 3))
         self.velocities = np.zeros((self.N, 3))
         self.accelerations = np.zeros((self.N, 3))
-        
+
+    @classmethod
+    def from_config(
+        cls,
+        config=None,
+        config_id=None,
+        settings_file="configuration/settings.toml"
+    ):
+        """ Setup the environment.
+
+        :param config: is a preset configuration defined? (T/F)
+        :param config_id: the ID of the particular initial
+            configuraiton defined in the settings.
+        :param settings_file: path of the settings to load.
+        """
+        settings = toml.load(settings_file)
+
+        if settings["environment"]["method"] == "HPC":
+            self = HuenPredictorEnvironment()
+            self._max_steps = settings["HPC"]["max_steps"]
+            self._epsilon = settings["HPC"]["epsilon"]
+        elif settings["environment"]["method"] == "RK":
+            self = RungeKuttaEnvironment()
+            self.order = int(settings["RK"]["order"])
+            self.rk_b = {int(key): val for key, val in settings["RK"]["B"].items()}
+            self.rk_c = {int(key): val for key, val in settings["RK"]["C"].items()}
+        else:
+            raise ValueError("Method must be one of HPC, RK")
+
+        self.dt = settings["environment"]["dt"]
+        self.t_max = settings["environment"]["t_max"]
+
+        if config is not None:
+            self.N = config.shape[0]
+            self.G = settings['configs'][config_id]['G']
+            self.initial_conditions = InitialCondition(config)
+        else:
+            self.N = settings['environment']['n']
+            self.G = settings['const']['G']
+
+        self.config = config
+        self.config_id = config_id
+        self.settings = settings
+
+        return self
+
     def _reset(self):
         """ Resets the environment back to default positions. """
         # Positions defined by a configuration. Overrides the default values.
-        if self.config is not None:
-            self.m = np.array(self.config['mass'])
-            self.positions = np.array(self.config[['x', 'y', 'z']])
-            self.velocities = np.array(self.config[['vx', 'vy', 'vz']])
-            self.accelerations = np.zeros((self.N, 2))
+        if self.initial_conditions is not None:
+            self.m = np.copy(self.initial_conditions.m)
+            self.positions = np.copy(self.initial_conditions.positions)
+            self.velocities = np.copy(self.initial_conditions.velocities)
         else:
             self.m = np.random.uniform(0, 2, (self.N, 1))
             self.positions = np.random.uniform(-100, 100, (self.N, 3))
             self.velocities = np.random.uniform(-1, 1, (self.N, 3))
-            self.accelerations = np.zeros((self.N, 2))
+
+        self.accelerations = np.zeros((self.N, 2))
         self.gt = 0
 
     def step(self):
         """ Update the environment a single timestep dt each call """
-        if self.gt < self.settings["environment"]["t_max"]:
-            if self.settings["environment"]["method"] == "HPC":
-                self.huen_predictor_corrector()  
-            elif self.settings["environment"]["method"] == "RK":
-                self.runge_kutta()
+        if self.gt < self.t_max:
+            self.iterate()
             self.gt += self.dt
+
+    def iterate(self):
+        pass
 
     def calculate_gravity_laws(self, positions):
         """ Calculates the net acceleration (ax, ay, az) due to 
         gravitation from all other bodies for all bodies.
         """
         force_between_bodies = np.zeros((self.N, self.N, 3))
-        for i in range(0, self.N-1):
-            for j in range(i+1, self.N):
+        for i in range(0, self.N - 1):
+            for j in range(i + 1, self.N):
                 # Newton's law of Gravitation
                 relative_position = positions[j] - positions[i]
                 l2_norm = np.linalg.norm(relative_position) + 1e-6
-                gravitational_force_ij = self.G*self.m[i]*self.m[j]*relative_position/l2_norm**3 
+                gravitational_force_ij = self.G * self.m[i] * self.m[j] * relative_position / l2_norm ** 3
 
                 # Fji = -Fij <=> Fij = -Fji
                 force_between_bodies[i, j] = gravitational_force_ij
                 force_between_bodies[j, i] = -gravitational_force_ij
-        
+
         # Net acceleration on each body
         accelerations = np.sum(force_between_bodies, axis=1) / self.m
 
         return accelerations
-
-    def runge_kutta(self):
-        """ Implementation of RK{1,2,3,4} with fixed step dt.
-        See documentation for more details.
-        """
-        order = self.settings["RK"]["order"]
-        
-        # State information to integrate [v0, ..., vn, a0, ..., an]
-        K_vals = np.zeros((order, self.N*2, 3)) 
-        K_vals[:, :self.N] = np.copy(self.velocities)
-
-        # Get the derivatives at each stage
-        for i in range(order):
-            if i > 0: 
-                RK_B = np.array(self.settings["RK"]["B"][str(order)][i]).reshape(-1,1)
-                RK_B = np.repeat(RK_B[:, :, np.newaxis], 3, axis=2)
-                K_vals[i, self.N:] = self.calculate_gravity_laws(
-                    self.positions + self.dt*np.sum(RK_B*K_vals[:-1, :self.N], axis=0)
-                )
-            else:
-                K_vals[i, self.N:] = self.calculate_gravity_laws(self.positions)
-
-        # Broadcast C for estimate updates
-        RK_C = np.array(self.settings["RK"]["C"][str(order)])
-        RK_C = np.repeat(RK_C[:, :, np.newaxis], 3, axis=2)
-
-        # Update position estimate
-        self.positions += np.sum(K_vals[:, :self.N]*RK_C*self.dt, axis=0)
-
-        # Update velocity estimate
-        self.velocities += np.sum(K_vals[:, self.N:]*RK_C*self.dt, axis=0)
-
-    def huen_predictor_corrector(self):
-        """ Implements Huen's predictor-corrector with fixed step dt.
-        See documentation for more details.
-        """
-        curr_step = 0
-        error = 1e99
-        y_t = np.vstack((self.positions, self.velocities))
-        y_predict = np.copy(y_t)
-        y_corrector = np.copy(y_t)
-
-        # Predictor
-        f_t_acc = self.calculate_gravity_laws(self.positions)
-        f_t_vel = self.velocities
-        f_t = np.vstack((f_t_vel, f_t_acc))
-        y_predict = np.vstack((self.positions, self.velocities)) + f_t*self.dt
-
-        # Keep correcting until desired accuracy or max steps reached
-        while curr_step < self.settings["HPC"]["max_steps"] and error > self.settings["HPC"]["epsilon"]:
-            # Corrector
-            f_t_acc = self.calculate_gravity_laws(y_predict[:self.N])
-            f_t_correct = np.vstack((y_predict[self.N:], f_t_acc))
-            average_accel = 0.5*(f_t + f_t_correct)
-            y_corrector = y_t + self.dt*average_accel
-
-            # Relative Error; added offset to avoid 0 denominator            
-            error = np.max(np.abs(y_corrector - y_predict)/(y_corrector + 1e-6))
-
-            y_predict = np.copy(y_corrector)
-            curr_step += 1
-
-        self.positions = y_predict[:self.N]
-        self.velocities = y_predict[self.N:]
 
     def collision_combine(self, collision_distance=3):
         """ Checks if any two particles are close, if they are 
@@ -167,3 +155,75 @@ class Environment:
         # If you do collide, make sure that you are picking the one which was closest... (interesting problem...)
         # import pdb; pdb.set_trace()
         pass
+
+
+class HuenPredictorEnvironment(Environment):
+    def __init__(self):
+        super().__init__()
+        self._max_steps = 0
+        self._epsilon = 0
+
+    def iterate(self):
+        """ Implements Huen's predictor-corrector with fixed step dt.
+        See documentation for more details.
+        """
+        curr_step = 0
+        error = 1e99
+        y_t = np.vstack((self.positions, self.velocities))
+
+        # Predictor
+        f_t_acc = self.calculate_gravity_laws(self.positions)
+        f_t_vel = self.velocities
+        f_t = np.vstack((f_t_vel, f_t_acc))
+        y_predict = np.vstack((self.positions, self.velocities)) + f_t * self.dt
+
+        # Keep correcting until desired accuracy or max steps reached
+        while curr_step < self._max_steps and error > self._epsilon:
+            # Corrector
+            f_t_acc = self.calculate_gravity_laws(y_predict[:self.N])
+            f_t_correct = np.vstack((y_predict[self.N:], f_t_acc))
+            average_accel = 0.5 * (f_t + f_t_correct)
+            y_corrector = y_t + self.dt * average_accel
+
+            # Relative Error; added offset to avoid 0 denominator
+            error = np.max(np.abs(y_corrector - y_predict) / (y_corrector + 1e-6))
+
+            y_predict = np.copy(y_corrector)
+            curr_step += 1
+
+        self.positions = y_predict[:self.N]
+        self.velocities = y_predict[self.N:]
+
+
+class RungeKuttaEnvironment(Environment):
+    def __init__(self):
+        super().__init__()
+        self.order = None
+        self.rk_b = None
+        self.rk_c = None
+
+    def iterate(self):
+        """ Implementation of RK{1,2,3,4} with fixed step dt.
+        See documentation for more details.
+        """
+        # State information to integrate [v0, ..., vn, a0, ..., an]
+        K_vals = np.zeros((self.order, self.N * 2, 3))
+        K_vals[:, :self.N] = np.copy(self.velocities)
+        # Get the derivatives at each stage
+        K_vals[0, self.N:] = self.calculate_gravity_laws(self.positions)
+        for i in range(1, self.order):
+            RK_B = np.array(self.rk_b[self.order][i]).reshape(-1, 1)
+            RK_B = np.repeat(RK_B[:, :, np.newaxis], 3, axis=2)
+            K_vals[i, self.N:] = self.calculate_gravity_laws(
+                self.positions + self.dt * np.sum(RK_B * K_vals[:-1, :self.N], axis=0)
+            )
+
+        # Broadcast C for estimate updates
+        RK_C = np.array(self.rk_c[self.order])
+        RK_C = np.repeat(RK_C[:, :, np.newaxis], 3, axis=2)
+
+        # Update position estimate
+        self.positions += np.sum(K_vals[:, :self.N] * RK_C * self.dt, axis=0)
+
+        # Update velocity estimate
+        self.velocities += np.sum(K_vals[:, self.N:] * RK_C * self.dt, axis=0)

--- a/run.py
+++ b/run.py
@@ -12,7 +12,7 @@ SETTINGS_FILE = "configuration/settings.toml"
 def enter_mode(config, train, view):
     """ Runs ORSAT in the desired mode. """
     if view:
-        vis = GUI(env.Environment(), toml.load(SETTINGS_FILE))
+        vis = GUI(Environment.from_config(), toml.load(SETTINGS_FILE))
         vis.animate()
     return
 


### PR DESCRIPTION
To make it easier to interact with the simulator, I added HuenPredictorEnvironment and RungeKuttaEnvironment classes - these implement a iterate method, which I just copied from the Environment classes' implementations of the functionality - this is helpful as it is no longer necessary to check which implementation is being used in step(), making this easier to extend in the future.

I added a from_config method which replaces the current __init__, which makes Environment creation more obvious. Instead of repeatedly getting the same information from self.settings / self.config, I also fetched all the information necessary:
eg. instead of repeatedly doing `while curr_step < self.settings["HPC"]["max_steps"]...`, it's clearer (and easier to type) to do `while curr_step < self.max_steps`.

I also tweaked the implementation for Renge-Kutta to be slightly more obvious (instead of checking if i == 0, which only happens once and at the start, set up the array first and then iterate over i = 1..self.N)